### PR TITLE
Ensure Handling of all Hafas errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "vahrplan",
-	"version": "2.3.0",
+	"version": "2.3.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "vahrplan",
-			"version": "2.3.0",
+			"version": "2.3.2",
 			"dependencies": {
 				"hafas-client": "^6.3.2",
 				"leaflet": "^1.9.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "vahrplan",
-	"version": "2.3.1",
+	"version": "2.3.2",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build",

--- a/src/lib/server/responses.ts
+++ b/src/lib/server/responses.ts
@@ -23,8 +23,8 @@ export function getZugErrorFromHafasError(
 			// handle this in a special way since this error is not thrown by hafas/hafas-client!!!
 			return getZugError("QUOTA_EXCEEDED");
 		}
-		description = `Hafas: ${error.hafasDescription ?? ""}`;
-		errorType = `HAFAS_${error.code}`;
+		description = `Hafas: ${error.hafasDescription ?? "Hafas-Fehler"}`;
+		errorType = `HAFAS_${error.code ?? "SERVER_ERROR"}`;
 	}
 	return {
 		isError: true,


### PR DESCRIPTION
This prevents `ZugError` objects from having the `code` property set to `null`, which leads the http response's error to be set to null, too. This is bad and may also lead to those responses to be cached by the client (see #66)