### PR TITLE
Console statement and naming convention linting rules

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -23,6 +23,7 @@ export default [
 	{
 		rules: {
 			"logical-assignment-operators": "error",
+			"no-console": "error",
 			"@typescript-eslint/consistent-type-definitions": ["error", "type"],
 			"@typescript-eslint/explicit-function-return-type": [
 				"error",

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -22,8 +22,8 @@ export default [
 	// ts config
 	{
 		rules: {
-			"@typescript-eslint/consistent-type-definitions": ["error", "type"],
 			"logical-assignment-operators": "error",
+			"@typescript-eslint/consistent-type-definitions": ["error", "type"],
 			"@typescript-eslint/explicit-function-return-type": [
 				"error",
 				{ allowConciseArrowFunctionExpressionsStartingWithVoid: true }
@@ -39,7 +39,40 @@ export default [
 					caughtErrorsIgnorePattern: "^_"
 				}
 			],
-			"@typescript-eslint/restrict-template-expressions": "error"
+			"@typescript-eslint/restrict-template-expressions": "error",
+			"@typescript-eslint/naming-convention": [
+				"error",
+				{
+					selector: "default",
+					format: ["strictCamelCase"],
+					leadingUnderscore: "allow",
+					trailingUnderscore: "allow"
+				},
+				{
+					selector: "import",
+					format: ["camelCase", "PascalCase"]
+				},
+				{
+					selector: "variable",
+					modifiers: ["const", "global"],
+					format: ["strictCamelCase", "UPPER_CASE"]
+				},
+				{
+					selector: "property",
+					modifiers: ["readonly"],
+					format: ["strictCamelCase", "UPPER_CASE"]
+				},
+				{
+					selector: "variable",
+					types: ["boolean"],
+					format: ["PascalCase"],
+					prefix: ["is", "has"]
+				},
+				{
+					selector: "typeLike",
+					format: ["PascalCase"]
+				}
+			]
 		}
 	},
 	{

--- a/src/lib/components/Header.svelte
+++ b/src/lib/components/Header.svelte
@@ -3,13 +3,13 @@
 
 	type Props = {
 		title: string;
-		mobileOnly?: boolean;
+		isMobileOnly?: boolean;
 		children?: Snippet;
 	};
-	let { title, mobileOnly = false, children }: Props = $props();
+	let { title, isMobileOnly = false, children }: Props = $props();
 </script>
 
-<header class="flex-row" class:mobile-only={mobileOnly}>
+<header class="flex-row" class:mobile-only={isMobileOnly}>
 	<strong class="limit-lines">{title}</strong>
 	<div class="buttons flex-row">
 		{@render children?.()}

--- a/src/lib/components/MiniTabs.svelte
+++ b/src/lib/components/MiniTabs.svelte
@@ -3,7 +3,7 @@
 	import SingleSelect from "$lib/components/SingleSelect.svelte";
 
 	type Props = {
-		padContent?: boolean;
+		isContentPadded?: boolean;
 		tabs: {
 			title: string; // for accessibility
 			icon: Snippet; // the icon used
@@ -14,7 +14,7 @@
 		startingTab?: number;
 	};
 
-	const { padContent = false, tabs, tabEnvironment, startingTab = 0 }: Props = $props();
+	const { isContentPadded = false, tabs, tabEnvironment, startingTab = 0 }: Props = $props();
 	const tabsWithType: ComponentProps<SingleSelect<"icon">>["titles"] = tabs.map((tab) => ({
 		title: tab.title,
 		icon: tab.icon,
@@ -29,7 +29,7 @@
 {/snippet}
 
 {#snippet tabContent()}
-	<div class:pad-content={padContent} class:full-height={tabs[activeTab].isFullHeight}>
+	<div class:pad-content={isContentPadded} class:full-height={tabs[activeTab].isFullHeight}>
 		{@render tabs[activeTab].content()}
 	</div>
 {/snippet}

--- a/src/lib/components/ProgressBar.svelte
+++ b/src/lib/components/ProgressBar.svelte
@@ -1,23 +1,23 @@
 <script lang="ts">
 	import { type LoadingStatus, loadingStatus } from "$lib/stores/loadingStore";
 
-	let resetWidth = $state(false);
+	let isWidthReset = $state(false);
 
 	$effect(() => resetLoadingBar($loadingStatus));
 
 	function resetLoadingBar(loadingStatus: LoadingStatus): void {
 		if (loadingStatus.status === "loading") {
-			resetWidth = true;
-			setTimeout(() => (resetWidth = false), 100);
+			isWidthReset = true;
+			setTimeout(() => (isWidthReset = false), 100);
 		}
 	}
 </script>
 
 <div
 	class="progress {$loadingStatus.status}"
-	class:reset-width={resetWidth}
+	class:reset-width={isWidthReset}
 	style:--loading-est={$loadingStatus.status === "loading" ? $loadingStatus.estimatedDuration : 0}
-	style:width={resetWidth ? 0 : ""}
+	style:width={isWidthReset ? 0 : ""}
 ></div>
 
 <style>

--- a/src/lib/components/ServiceWorkerUpdates.svelte
+++ b/src/lib/components/ServiceWorkerUpdates.svelte
@@ -38,13 +38,13 @@
 	}
 
 	if (browser && "serviceWorker" in navigator) {
-		let refreshing: boolean;
+		let isRefreshing: boolean;
 		const isFirstVisit = navigator.serviceWorker.controller === null; // no service worker yet?
 		let reg = navigator.serviceWorker.register("./service-worker.js");
 
 		navigator.serviceWorker.addEventListener("controllerchange", () => {
-			if (refreshing) return; // prevent infinite reloads when debugging
-			refreshing = true;
+			if (isRefreshing) return; // prevent infinite reloads when debugging
+			isRefreshing = true;
 			window.location.reload();
 		});
 

--- a/src/lib/components/TrainProgressIndicator.svelte
+++ b/src/lib/components/TrainProgressIndicator.svelte
@@ -22,7 +22,7 @@
 
 		// This ensures that the animation starts even if the element is child of a collapsed details node
 		indicatorContainer.style.animation = "none";
-		const _ = indicatorContainer.offsetHeight;
+		void indicatorContainer.offsetHeight;
 		indicatorContainer.style.animation = "";
 	});
 
@@ -36,7 +36,7 @@
 			departureTime = departureTime + 1;
 			departureTime = departureTime - 1; // update animation start by invalidating departure time
 			indicatorContainer.style.animation = "none"; // set animation to none
-			const _ = indicatorContainer.offsetHeight; // element reflow
+			void indicatorContainer.offsetHeight; // element reflow
 			indicatorContainer.style.animation = ""; // re-apply css animation
 		}
 	}

--- a/src/lib/components/splitPane/SplitPane.svelte
+++ b/src/lib/components/splitPane/SplitPane.svelte
@@ -10,7 +10,7 @@
 		min?: Length;
 		max?: Length;
 		priority?: "min" | "max";
-		disabled?: boolean;
+		isDisabled?: boolean;
 		leftPane: Snippet;
 		rightPane: Snippet;
 	};
@@ -21,14 +21,14 @@
 		min = "0%",
 		max = "100%",
 		priority = "min",
-		disabled = false,
+		isDisabled = false,
 		leftPane,
 		rightPane
 	}: Props = $props();
 
 	let container: HTMLElement | undefined;
 
-	let dragging = $state(false);
+	let isDragging = $state(false);
 	let size = $state(0);
 
 	let desiredPosition = $state(pos);
@@ -40,13 +40,13 @@
 	onMount(() => setTimeout(() => (isLoading = false), 400));
 
 	function update(x: number): void {
-		if (disabled || container === undefined) return;
+		if (isDisabled || container === undefined) return;
 
 		const { left } = container.getBoundingClientRect();
 
-		const pos_px = x - left;
+		const posPx = x - left;
 
-		desiredPosition = pos.endsWith("%") ? `${(100 * pos_px) / size}%` : `${pos_px}px`;
+		desiredPosition = pos.endsWith("%") ? `${(100 * posPx) / size}%` : `${posPx}px`;
 	}
 
 	function drag(
@@ -64,10 +64,10 @@
 
 			event.preventDefault();
 
-			dragging = true;
+			isDragging = true;
 
 			const onpointerup = (): void => {
-				dragging = false;
+				isDragging = false;
 
 				node.setPointerCapture(event.pointerId);
 
@@ -101,16 +101,20 @@
 		{@render leftPane()}
 	</div>
 
-	{#if !disabled}
+	{#if !isDisabled}
 		<div class="pane">
 			{@render rightPane()}
 		</div>
-		<div class="divider" class:disabled class:dragging use:drag={(e) => void update(e.clientX)}
+		<div
+			class="divider"
+			class:disabled={isDisabled}
+			class:dragging={isDragging}
+			use:drag={(e) => void update(e.clientX)}
 		></div>
 	{/if}
 </div>
 
-{#if dragging}
+{#if isDragging}
 	<div class="mousecatcher"></div>
 {/if}
 

--- a/src/lib/components/splitPane/utils.ts
+++ b/src/lib/components/splitPane/utils.ts
@@ -13,20 +13,20 @@ export function constrain(
 	if (element === undefined) {
 		return "100%";
 	}
-	let min_px = normalize(min, element, size);
-	let max_px = normalize(max, element, size);
-	let pos_px = normalize(pos, element, size);
+	let minPx = normalize(min, element, size);
+	let maxPx = normalize(max, element, size);
+	let posPx = normalize(pos, element, size);
 
-	if (min_px < 0) min_px += size;
-	if (max_px < 0) max_px += size;
-	if (pos_px < 0) pos_px += size;
+	if (minPx < 0) minPx += size;
+	if (maxPx < 0) maxPx += size;
+	if (posPx < 0) posPx += size;
 
-	pos_px =
+	posPx =
 		priority === "min"
-			? Math.max(min_px, Math.min(max_px, pos_px))
-			: Math.min(max_px, Math.max(min_px, pos_px));
+			? Math.max(minPx, Math.min(maxPx, posPx))
+			: Math.min(maxPx, Math.max(minPx, posPx));
 
-	return pos.endsWith("%") ? (size ? `${(100 * pos_px) / size}%` : "0%") : `${pos_px}px`;
+	return pos.endsWith("%") ? (size ? `${(100 * posPx) / size}%` : "0%") : `${posPx}px`;
 }
 
 function normalize(str: string, element: HTMLElement, size: number): number {

--- a/src/lib/geolocation.svelte.ts
+++ b/src/lib/geolocation.svelte.ts
@@ -77,10 +77,8 @@ async function watchDeviceOrientation(): Promise<() => void> {
 	) {
 		// ios
 		// @ts-expect-error proprietary ios function `requestPermission()` is not recognized by typescript
-		// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-call,@typescript-eslint/no-unsafe-member-access
-		const permissionState = await DeviceOrientationEvent.requestPermission().catch(
-			console.error
-		);
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment,@typescript-eslint/no-unsafe-call
+		const permissionState = await DeviceOrientationEvent.requestPermission();
 
 		if (permissionState !== "granted") {
 			return () => void {};

--- a/src/lib/merge.ts
+++ b/src/lib/merge.ts
@@ -77,15 +77,15 @@ export function getMergingBlock(
 				succeedingBlock.departureData.location.position
 			)
 		) {
-			const mergeWithStopover = precedingBlock.blockKey === succeedingBlock.blockKey;
-			precedingBlock.succeededBy = mergeWithStopover ? "stopover" : "transfer";
-			succeedingBlock.precededBy = mergeWithStopover ? "stopover" : "transfer";
+			const isMergeWithStopover = precedingBlock.blockKey === succeedingBlock.blockKey;
+			precedingBlock.succeededBy = isMergeWithStopover ? "stopover" : "transfer";
+			succeedingBlock.precededBy = isMergeWithStopover ? "stopover" : "transfer";
 			return transferToBlock(
 				precedingBlock.arrivalData,
 				precedingBlock.product ?? "",
 				succeedingBlock.departureData,
 				succeedingBlock.product ?? "",
-				mergeWithStopover
+				isMergeWithStopover
 			);
 		} else {
 			precedingBlock.succeededBy = undefined;

--- a/src/lib/merge.ts
+++ b/src/lib/merge.ts
@@ -48,11 +48,9 @@ export function getMergingBlock(
 			succeedingBlock?.type !== "leg" &&
 			succeedingBlock?.type !== "location")
 	) {
-		console.error(precedingBlock?.type);
-		console.error(succeedingBlock?.type);
 		// this should not happen at normal instances
 		// since first and last blocks of journeys are expected to be of type DefiningBlock!
-		return undefined;
+		throw new Error();
 	} else if (precedingBlock.type === "unselected" && succeedingBlock.type === "unselected") {
 		return getRawLocationBlock(location);
 	} else if (precedingBlock.type === "unselected" || succeedingBlock.type === "unselected") {

--- a/src/lib/server/RateLimiter.ts
+++ b/src/lib/server/RateLimiter.ts
@@ -5,7 +5,7 @@ import { getSuccessResponse, getZugError } from "$lib/server/responses";
  * A utility class allowing to rate-limit access to a limited resource
  */
 export class RateLimiter {
-	private readonly recentRequestsCounts: Map<string, number>; // Tracks for each accessor how many requests were sent in the last `RATE_LIMIT_INTERVAL` seconds
+	private readonly RECENT_REQUESTS_COUNTS: Map<string, number>; // Tracks for each accessor how many requests were sent in the last `RATE_LIMIT_INTERVAL` seconds
 	private readonly RATE_LIMIT_THRESHOLD: number;
 
 	/**
@@ -13,16 +13,16 @@ export class RateLimiter {
 	 * @param threshold the amount of times an accessor can access a resource
 	 */
 	constructor(interval: number, threshold: number) {
-		this.recentRequestsCounts = new Map();
+		this.RECENT_REQUESTS_COUNTS = new Map();
 		this.RATE_LIMIT_THRESHOLD = threshold;
-		setInterval(() => this.recentRequestsCounts.clear(), interval * 1000);
+		setInterval(() => this.RECENT_REQUESTS_COUNTS.clear(), interval * 1000);
 	}
 
 	accessResource<T>(accessor: string, resourceFn: () => T): ZugResponse<T> {
-		const accessorAccesses = this.recentRequestsCounts.get(accessor) ?? 0;
+		const accessorAccesses = this.RECENT_REQUESTS_COUNTS.get(accessor) ?? 0;
 		if (accessorAccesses < this.RATE_LIMIT_THRESHOLD) {
 			// allow access
-			this.recentRequestsCounts.set(accessor, accessorAccesses + 1);
+			this.RECENT_REQUESTS_COUNTS.set(accessor, accessorAccesses + 1);
 			return getSuccessResponse(resourceFn());
 		}
 		return getZugError("QUOTA_EXCEEDED");

--- a/src/lib/server/responses.ts
+++ b/src/lib/server/responses.ts
@@ -53,30 +53,41 @@ export function getSuccessResponse<T>(content: T): ZugSuccess<T> {
 }
 
 function getErrorCodeFromErrorType(type: ZugErrorType): ZugError["code"] {
-	return {
-		HAFAS_ACCESS_DENIED: 403,
-		HAFAS_INVALID_REQUEST: 400,
-		HAFAS_NOT_FOUND: 404,
-		HAFAS_SERVER_ERROR: 500,
-		NOT_FOUND: 404,
-		ERROR: 500,
-		QUOTA_EXCEEDED: 429,
-		HAFAS_QUOTA_EXCEEDED: 429
-	}[type] as ZugError["code"];
+	switch (type) {
+		case "HAFAS_INVALID_REQUEST":
+			return 400;
+		case "HAFAS_ACCESS_DENIED":
+			return 403;
+		case "HAFAS_NOT_FOUND":
+		case "NOT_FOUND":
+			return 404;
+		case "QUOTA_EXCEEDED":
+		case "HAFAS_QUOTA_EXCEEDED":
+			return 429;
+		case "ERROR":
+		case "HAFAS_SERVER_ERROR":
+			return 500;
+	}
 }
 
 function getDescriptionFromErrorType(type: ZugErrorType): string {
-	return {
-		HAFAS_ACCESS_DENIED: "Hafas: Zugriff verweigert.",
-		HAFAS_INVALID_REQUEST: "Hafas: ungültige Anfrage.",
-		HAFAS_NOT_FOUND: "Hafas: Ressource nicht gefunden.",
-		HAFAS_SERVER_ERROR: "Hafas: Server-Fehler.",
-		NOT_FOUND: "Ressource nicht gefunden.",
-		ERROR: "Server-Fehler.",
-		QUOTA_EXCEEDED: "Das Anfragelimit für Hafas ist überschritten. Versuche es später erneut.",
-		HAFAS_QUOTA_EXCEEDED:
-			"Das Anfragelimit für Hafas ist überschritten. Versuche es später erneut."
-	}[type];
+	switch (type) {
+		case "HAFAS_INVALID_REQUEST":
+			return "Hafas: ungültige Anfrage.";
+		case "HAFAS_ACCESS_DENIED":
+			return "Hafas: Zugriff verweigert.";
+		case "HAFAS_NOT_FOUND":
+			return "Hafas: Ressource nicht gefunden."
+		case "NOT_FOUND":
+			return "Ressource nicht gefunden.";
+		case "QUOTA_EXCEEDED":
+		case "HAFAS_QUOTA_EXCEEDED":
+			return "Das Anfragelimit für Hafas ist überschritten. Versuche es später erneut.";
+		case "ERROR":
+			return "Server-Fehler."
+		case "HAFAS_SERVER_ERROR":
+			return "Hafas: Server-Fehler.";
+	}
 }
 
 /**

--- a/src/lib/server/responses.ts
+++ b/src/lib/server/responses.ts
@@ -77,14 +77,14 @@ function getDescriptionFromErrorType(type: ZugErrorType): string {
 		case "HAFAS_ACCESS_DENIED":
 			return "Hafas: Zugriff verweigert.";
 		case "HAFAS_NOT_FOUND":
-			return "Hafas: Ressource nicht gefunden."
+			return "Hafas: Ressource nicht gefunden.";
 		case "NOT_FOUND":
 			return "Ressource nicht gefunden.";
 		case "QUOTA_EXCEEDED":
 		case "HAFAS_QUOTA_EXCEEDED":
 			return "Das Anfragelimit für Hafas ist überschritten. Versuche es später erneut.";
 		case "ERROR":
-			return "Server-Fehler."
+			return "Server-Fehler.";
 		case "HAFAS_SERVER_ERROR":
 			return "Hafas: Server-Fehler.";
 	}

--- a/src/lib/server/serverUtils.ts
+++ b/src/lib/server/serverUtils.ts
@@ -9,6 +9,7 @@ import { hash } from "node:crypto";
 export async function setDatabaseEntry<T>(entry: DatabaseEntry<T>): Promise<void> {
 	const key = `${entry.type}:${entry.key}`;
 	const value = JSON.stringify(entry.value);
+	// eslint-disable-next-line @typescript-eslint/naming-convention
 	await valkeyClient.set(key, value, { PXAT: entry.expirationDate });
 }
 

--- a/src/lib/server/setup.ts
+++ b/src/lib/server/setup.ts
@@ -12,7 +12,5 @@ export let valkeyClient: Awaited<ReturnType<typeof createRedisClient>>;
 if (!building) {
 	valkeyClient = await createRedisClient({
 		url: process.env.DATABASE_URL ?? "redis://localhost:6379"
-	})
-		.on("error", (err) => console.error(err))
-		.connect();
+	}).connect();
 }

--- a/src/lib/stores/journeyStores.ts
+++ b/src/lib/stores/journeyStores.ts
@@ -105,9 +105,6 @@ export function updateDisplayedLocations(
 		}
 
 		const locations = updateLocationsFn(formData);
-		if (formData.locations === locations) {
-			console.log("SAME");
-		}
 		if (locations.length < 2) {
 			toast("Mindestens zwei Stationen sind notwendig.", "red");
 			return formData;
@@ -202,10 +199,9 @@ async function calculateDiagram(formData: DisplayedFormData | undefined): Promis
 	}
 	const url = getApiJourneysUrl(formData);
 	const loadingEst = formData.locations.length * 3;
-	return getApiData<Diagram>(url, loadingEst).then((response) => {
-		console.log(response);
-		return response.isError ? { recommendedVias: [], tree: [] } : response.content;
-	});
+	return getApiData<Diagram>(url, loadingEst).then((response) =>
+		response.isError ? { recommendedVias: [], tree: [] } : response.content
+	);
 }
 
 /**

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -17,10 +17,10 @@
 			// ignore requests to other domains
 			return;
 		}
-		const loadingID = startLoading(2);
+		const loadingId = startLoading(2);
 		navigation.complete.then(
-			() => stopLoading(loadingID, false),
-			() => stopLoading(loadingID, true)
+			() => stopLoading(loadingId, false),
+			() => stopLoading(loadingId, true)
 		);
 	});
 </script>

--- a/src/routes/+page.ts
+++ b/src/routes/+page.ts
@@ -1,1 +1,2 @@
+// eslint-disable-next-line @typescript-eslint/naming-convention
 export const prerender = true;

--- a/src/routes/MainForm.svelte
+++ b/src/routes/MainForm.svelte
@@ -43,7 +43,7 @@
 	});
 
 	let departureArrivalSelection: 0 | 1 = $state(0);
-	let timeIsNow = $state(true);
+	let isTimeNow = $state(true);
 	let time = $state(dateToInputDate(new Date()));
 
 	$effect.pre(() => initTimeInputs(initialFormData));
@@ -51,13 +51,13 @@
 	function initTimeInputs(displayedFormData: DisplayedFormData | undefined): void {
 		if (displayedFormData === undefined) {
 			departureArrivalSelection = 0;
-			timeIsNow = true;
+			isTimeNow = true;
 			time = dateToInputDate(new Date());
 			return;
 		}
 
 		departureArrivalSelection = displayedFormData.timeRole === "arrival" ? 1 : 0;
-		timeIsNow =
+		isTimeNow =
 			~~(new Date().getTime() / 60000) === ~~(displayedFormData.time.getTime() / 60000);
 		time = dateToInputDate(displayedFormData.time);
 	}
@@ -86,7 +86,7 @@
 		if (!verifyUserInput(stopsToBeDisplayed.map((s) => s.value))) {
 			return;
 		}
-		const journeyTime = timeIsNow ? new Date() : new Date(time);
+		const journeyTime = isTimeNow ? new Date() : new Date(time);
 		journeyTime.setSeconds(0, 0); // round minute to improve caching behaviour
 		const timeRole: TransitType = departureArrivalSelection === 0 ? "departure" : "arrival";
 		const options = get(settings).journeysOptions;
@@ -193,7 +193,7 @@
 			{/each}
 		</div>
 	</div>
-	<div class="time-filter-submit" class:time-is-now={timeIsNow}>
+	<div class="time-filter-submit" class:time-is-now={isTimeNow}>
 		<div class="flex-row">
 			<SingleSelect
 				titles={[
@@ -204,12 +204,12 @@
 			/>
 			<Setting
 				settingName="jetzt"
-				bind:setting={timeIsNow}
+				bind:setting={isTimeNow}
 				settingInfo={{ type: "boolean" }}
 			/>
 		</div>
 		<div class="time-input-container">
-			{#if timeIsNow !== undefined && !timeIsNow}
+			{#if isTimeNow !== undefined && !isTimeNow}
 				<input
 					transition:scale
 					class="hoverable hoverable--visible"

--- a/src/routes/StationInput.svelte
+++ b/src/routes/StationInput.svelte
@@ -28,7 +28,7 @@
 	let inputText = $state(selectedLocation?.name ?? "");
 	let inputElement: HTMLInputElement;
 	let focused = $state(0);
-	let blurredInputWithSelection = $state(true);
+	let isInputBlurredBySelection = $state(true);
 
 	let bookmarkedLocations: ParsedLocation[] = $state([]);
 	let apiSuggestions: Promise<ParsedLocation[]> = $derived(
@@ -59,7 +59,7 @@
 	 * selects the first suggested location if the user leaves the input without a selection
 	 */
 	function handleInputBlur(): void {
-		blurredInputWithSelection = false; // this is reset to `true` in `handleSuggestionClick()`, otherwise it remains `false`
+		isInputBlurredBySelection = false; // this is reset to `true` in `handleSuggestionClick()`, otherwise it remains `false`
 		setTimeout(() => {
 			if (inputText.trim().length === 0) {
 				// the user probably intended to remove the station previously selected here
@@ -67,7 +67,7 @@
 				return;
 			}
 			if (
-				!blurredInputWithSelection && // no suggestion was selected
+				!isInputBlurredBySelection && // no suggestion was selected
 				inputText.trim() !== selectedLocation?.name // the selected location isn't what the user typed in
 			) {
 				// select the first suggested location
@@ -106,7 +106,7 @@
 		selectedLocation = suggestion;
 		inputText = isSimpleInput ? "" : suggestion.name;
 		focused = 0;
-		blurredInputWithSelection = true;
+		isInputBlurredBySelection = true;
 	}
 
 	function handleInputKeydown(ev: KeyboardEvent): void {
@@ -157,7 +157,7 @@
 				bind:value={inputText}
 				onkeydown={handleInputKeydown}
 				onblur={handleInputBlur}
-				onfocus={() => void (blurredInputWithSelection = false)}
+				onfocus={() => void (isInputBlurredBySelection = false)}
 			/>
 			{#if inputText !== ""}
 				<button

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -11,7 +11,7 @@
 	<meta name="description" content="Weiterführende Informationen über Vahrplan" />
 </svelte:head>
 
-<Header title={"Über diese Seite"} mobileOnly={true} />
+<Header title={"Über diese Seite"} isMobileOnly={true} />
 <div class="content-wrapper padded-top-bottom">
 	<h1>Name</h1>
 	Vahrplan steht für

--- a/src/routes/about/imprint/+page.svelte
+++ b/src/routes/about/imprint/+page.svelte
@@ -15,7 +15,7 @@
 	<meta name="robots" content="noindex,follow" />
 </svelte:head>
 
-<Header title="Impressum" mobileOnly={true} />
+<Header title="Impressum" isMobileOnly={true} />
 <div class="content-wrapper padded-top-bottom">
 	<h1 class="desktop-only">Impressum</h1>
 	<p>

--- a/src/routes/about/privacy/+page.svelte
+++ b/src/routes/about/privacy/+page.svelte
@@ -15,7 +15,7 @@
 	<meta name="robots" content="noindex,follow" />
 </svelte:head>
 
-<Header title={"Datenschutzerklärung"} mobileOnly={true} />
+<Header title={"Datenschutzerklärung"} isMobileOnly={true} />
 <div class="content-wrapper padded-top-bottom">
 	<h1 class="desktop-only">Datenschutz&shy;erkl&auml;rung</h1>
 	<h2>1. Datenschutz auf einen Blick</h2>

--- a/src/routes/api/diagram/treePlantation.server.ts
+++ b/src/routes/api/diagram/treePlantation.server.ts
@@ -73,8 +73,8 @@ async function getJourneyArrays(
 	transitType: TransitType
 ): Promise<ZugResponse<SubJourney[][]>> {
 	// if `transitType` is `arrival`, the journeys have to be searched in reverse order
-	const reverseOrder = transitType === "arrival";
-	const complimentaryTransitType = reverseOrder ? "departure" : "arrival";
+	const isReverseOrder = transitType === "arrival";
+	const complimentaryTransitType = isReverseOrder ? "departure" : "arrival";
 	const fallbackDate = new Date(transitType === "departure" ? 0 : MAX_DATE);
 
 	const journeyss: SubJourney[][] = [];
@@ -88,10 +88,10 @@ async function getJourneyArrays(
 		opt
 	};
 
-	const start = reverseOrder ? stops.length - 2 : 0;
-	const step = reverseOrder ? -1 : 1;
+	const start = isReverseOrder ? stops.length - 2 : 0;
+	const step = isReverseOrder ? -1 : 1;
 
-	for (let i = start; reverseOrder ? i >= 0 : i < stops.length - 1; i += step) {
+	for (let i = start; isReverseOrder ? i >= 0 : i < stops.length - 1; i += step) {
 		fromToOpt.from = stops[i];
 		fromToOpt.to = stops[i + 1];
 		let depthJourneys;
@@ -101,12 +101,12 @@ async function getJourneyArrays(
 			return getZugErrorFromHafasError(e, i, i + 1);
 		}
 		fromToOpt.opt[transitType] =
-			depthJourneys.at(reverseOrder ? -1 : 0)?.[`${complimentaryTransitType}Time`]?.time ??
+			depthJourneys.at(isReverseOrder ? -1 : 0)?.[`${complimentaryTransitType}Time`]?.time ??
 			fallbackDate;
 
 		journeyss[i] = depthJourneys;
 		timeLimit.date =
-			depthJourneys.at(reverseOrder ? 0 : -1)?.[`${complimentaryTransitType}Time`]?.time ??
+			depthJourneys.at(isReverseOrder ? 0 : -1)?.[`${complimentaryTransitType}Time`]?.time ??
 			fallbackDate;
 	}
 

--- a/src/routes/bookmarks/+page.svelte
+++ b/src/routes/bookmarks/+page.svelte
@@ -38,7 +38,7 @@
 	<StationBookmarks />
 {/snippet}
 
-<Header title="Lesezeichen" mobileOnly={true} />
+<Header title="Lesezeichen" isMobileOnly={true} />
 <div class="content-wrapper" data-sveltekit-preload-data="off">
 	<Tabs tabs={tabContent} isBelowHeaderMobile={true} />
 </div>

--- a/src/routes/diagram/+page.svelte
+++ b/src/routes/diagram/+page.svelte
@@ -58,7 +58,7 @@
 
 	let windowWidth: number = $state(0);
 
-	let showSplitPane = $derived(windowWidth >= 1000);
+	let isShowSplitPane = $derived(windowWidth >= 1000);
 
 	$effect(() => {
 		resetDiagram($page.data.formData);
@@ -77,7 +77,7 @@
 		pageData.formData = undefined;
 	}
 
-	let allSelected = $derived($selectedJourneys.every((journey) => journey.selectedBy !== -1));
+	let isAllSelected = $derived($selectedJourneys.every((journey) => journey.selectedBy !== -1));
 </script>
 
 <svelte:head>
@@ -89,9 +89,9 @@
 <div class="split-container" bind:clientWidth={windowWidth}>
 	<SplitPane
 		min="360px"
-		max={showSplitPane ? "-360px" : "100%"}
-		pos={showSplitPane ? "-30rem" : "100%"}
-		disabled={!showSplitPane}
+		max={isShowSplitPane ? "-360px" : "100%"}
+		pos={isShowSplitPane ? "-30rem" : "100%"}
+		isDisabled={!isShowSplitPane}
 	>
 		{#snippet leftPane()}
 			<div
@@ -103,7 +103,7 @@
 				</section>
 				<section class="diagram">
 					{#if $displayedFormData !== undefined}
-						<JourneySummary {allSelected} />
+						<JourneySummary {isAllSelected} />
 						{#await $displayedDiagram}
 							<JourneyDiagramSkeleton
 								depth={$displayedFormData.locations.length - 1}
@@ -119,7 +119,7 @@
 		{/snippet}
 		{#snippet rightPane()}
 			<div class="journey-preview">
-				{#if showSplitPane}
+				{#if isShowSplitPane}
 					{#snippet detailsIcon()}
 						<IconJourneyInfo />
 					{/snippet}

--- a/src/routes/diagram/+page.ts
+++ b/src/routes/diagram/+page.ts
@@ -37,8 +37,8 @@ export const load: PageLoad = async ({ url, fetch }) => {
 			error(requestDataResponse.code, requestDataResponse.description);
 		}
 
-		const diagramURL = getDiagramUrlFromRequestData(requestDataResponse.content);
-		redirect(303, diagramURL);
+		const diagramUrl = getDiagramUrlFromRequestData(requestDataResponse.content);
+		redirect(303, diagramUrl);
 	}
 
 	if (url.searchParams.size === 0) {

--- a/src/routes/diagram/JourneySummary.svelte
+++ b/src/routes/diagram/JourneySummary.svelte
@@ -31,10 +31,10 @@
 	import TrainProgressIndicator from "$lib/components/TrainProgressIndicator.svelte";
 
 	type Props = {
-		allSelected: boolean;
+		isAllSelected: boolean;
 	};
 
-	let { allSelected }: Props = $props();
+	let { isAllSelected }: Props = $props();
 
 	type JourneyInfo = {
 		legs: LegBlock[];
@@ -88,7 +88,7 @@
 
 <TitlelessHeader --header-width="calc(var(--diagram-width) - 2rem">
 	<div id="journey-summary" class="flex-column summary-background">
-		<div class="flex-row actions" class:all-selected={allSelected}>
+		<div class="flex-row actions" class:all-selected={isAllSelected}>
 			{#await $displayedDiagram then { recommendedVias }}
 				<ViaRecommendations {recommendedVias} />
 			{/await}
@@ -106,7 +106,7 @@
 			>
 				<IconBookmark {isBookmarked} />
 			</button>
-			{#if allSelected}
+			{#if isAllSelected}
 				<a
 					href={getJourneyUrl($selectedJourneys).href}
 					class="hoverable hoverable--accent"

--- a/src/routes/journey/+page.svelte
+++ b/src/routes/journey/+page.svelte
@@ -26,7 +26,7 @@
 		let formData1: DisplayedFormData;
 		if (formData !== undefined) {
 			formData1 = formData;
-		} else if ($displayedFormData !== undefined && allSelected) {
+		} else if ($displayedFormData !== undefined && isAllSelected) {
 			formData1 = $displayedFormData;
 		} else {
 			return {
@@ -46,7 +46,7 @@
 
 	let clientWidth: number = $state(0);
 
-	let allSelected = $derived($selectedJourneys.every((journey) => journey.selectedBy !== -1));
+	let isAllSelected = $derived($selectedJourneys.every((journey) => journey.selectedBy !== -1));
 </script>
 
 <svelte:head>
@@ -95,7 +95,7 @@
 		startingTab={$settings.general.journeyDetailsStandardView === "classic" ? 0 : 1}
 	>
 		{#snippet tabEnvironment(miniTabSelector: Snippet, tabContent: Snippet)}
-			<Header title={pageTitle.length === 0 ? "Reisedetails" : pageTitle} mobileOnly={true}>
+			<Header title={pageTitle.length === 0 ? "Reisedetails" : pageTitle} isMobileOnly={true}>
 				{@render miniTabSelector()}
 				<JourneyOptions />
 			</Header>

--- a/src/routes/journey/JourneyOptions.svelte
+++ b/src/routes/journey/JourneyOptions.svelte
@@ -12,7 +12,7 @@
 	import IconRefresh from "$lib/components/icons/IconRefresh.svelte";
 	import ResponsiveOptions from "$lib/components/ResponsiveOptions.svelte";
 
-	let allSelected = $derived($selectedJourneys.every((journey) => journey.selectedBy !== -1));
+	let isAllSelected = $derived($selectedJourneys.every((journey) => journey.selectedBy !== -1));
 
 	let journeyBookmarks: JourneyBookmark[] = $state([]);
 
@@ -70,6 +70,6 @@
 	<IconTickets />
 {/snippet}
 
-{#if allSelected && $selectedJourneys.length > 0}
+{#if isAllSelected && $selectedJourneys.length > 0}
 	<ResponsiveOptions id="journey-options" {options} />
 {/if}

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -13,7 +13,7 @@
 	<meta name="description" content="Einstellungen für Vahrplan" />
 </svelte:head>
 
-<Header title={"Einstellungen"} mobileOnly={true} />
+<Header title={"Einstellungen"} isMobileOnly={true} />
 <div class="content-wrapper">
 	<h1>Farben</h1>
 	<Setting


### PR DESCRIPTION
Introduces two more linting rules:
- `no-console`: Fails if there are console statements
- `@typescript-eslint/naming-convention`: Enforces naming conventions