### PR TITLE
redact plausible route params

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "vahrplan",
-	"version": "4.0.0",
+	"version": "4.0.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "vahrplan",
-			"version": "4.0.0",
+			"version": "4.0.1",
 			"dependencies": {
 				"db-vendo-client": "^6.3.4",
 				"hafas-client": "^6.3.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "vahrplan",
-	"version": "4.0.0",
+	"version": "4.0.1",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build",

--- a/src/lib/api-client/ApiClient.ts
+++ b/src/lib/api-client/ApiClient.ts
@@ -90,7 +90,7 @@ export abstract class ApiClient<
 		if (browser && window.plausible && typeof plausible === "function") {
 			// @ts-expect-error plausible
 			// eslint-disable-next-line @typescript-eslint/no-unsafe-call
-			plausible(url.pathname);
+			plausible(this.route);
 		}
 
 		requestInit.method = this.methodType;


### PR DESCRIPTION
With v4, some api routes now use path params. Forgot redacting those for analytics...