### PR TITLE
disable hyphens for duration component

### DIFF
--- a/src/lib/components/Duration.svelte
+++ b/src/lib/components/Duration.svelte
@@ -35,6 +35,7 @@
 	.align-right {
 		display: flex;
 		white-space: unset;
+		hyphens: none;
 		margin: auto 0 auto auto;
 		direction: rtl;
 		width: 0;


### PR DESCRIPTION
In Safari, durations were hyphenated without intention.