### PR TITLE
Fix safari timestamp bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "vahrplan",
-	"version": "5.1.1",
+	"version": "5.1.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "vahrplan",
-			"version": "5.1.1",
+			"version": "5.1.2",
 			"dependencies": {
 				"db-vendo-client": "^6.10.8",
 				"hafas-client": "^6.3.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "vahrplan",
-	"version": "5.1.1",
+	"version": "5.1.2",
 	"scripts": {
 		"dev": "vite dev",
 		"build": "vite build",

--- a/src/lib/geolocation.svelte.ts
+++ b/src/lib/geolocation.svelte.ts
@@ -168,7 +168,7 @@ export async function getCurrentGeolocation(): Promise<ParsedGeolocation | undef
 		navigator.geolocation.getCurrentPosition(
 			(position) => {
 				const currentLocation: ParsedLocation = getParsedGeolocation(
-					new SvelteDate(position.timestamp),
+					new SvelteDate(Date.now()),
 					{
 						lat: position.coords.latitude,
 						lng: position.coords.longitude,


### PR DESCRIPTION
Fixes #283 

Instead of using the timestamp returned by `navigator.geolocation.getCurrentPosition()`, use `Date.now()`